### PR TITLE
feat: reconnect api and check login

### DIFF
--- a/waffle_recruit_front/src/App.tsx
+++ b/waffle_recruit_front/src/App.tsx
@@ -61,9 +61,7 @@ const App = () => {
         draggable
         pauseOnHover
       />
-      {
-        <MainModal />
-      }
+      <MainModal />
     </>
   );
 };

--- a/waffle_recruit_front/src/apis/requester.ts
+++ b/waffle_recruit_front/src/apis/requester.ts
@@ -3,9 +3,9 @@ import axios from 'axios';
 import { loadJWT } from './token';
 
 // TODO .env.production
-const isProduction = false;
+const isProduction = true;
 
-const baseURL = isProduction ? 'https://recruit-api.wafflestudio.com' : 'http://localhost:8000';
+const baseURL = isProduction ? 'https://recruit2022-api.wafflestudio.com' : 'http://localhost:8000';
 
 export const requester = axios.create({
   baseURL: baseURL,
@@ -20,7 +20,7 @@ export const authRequester = axios.create({
 
 authRequester.interceptors.request.use(
   (config) => {
-    config.headers.Authorization = loadJWT();
+    config.headers.Authorization = `Bearer ${loadJWT()}`;
     return config;
   },
   (error) => {

--- a/waffle_recruit_front/src/apis/token.ts
+++ b/waffle_recruit_front/src/apis/token.ts
@@ -1,4 +1,4 @@
-const jwtKey = 'jwt' as const;
+const jwtKey = 'access' as const;
 const refreshKey = 'refresh' as const;
 
 export const loadJWT = () => {
@@ -14,4 +14,9 @@ export const saveJWT = (token: string) => {
 };
 export const saveRefresh = (token: string) => {
   return localStorage.setItem(refreshKey, token);
+};
+
+export const saveTokens = ({ access, refresh }: { access: string; refresh: string }) => {
+  saveJWT(access);
+  saveRefresh(refresh);
 };

--- a/waffle_recruit_front/src/pages/AuthorizedRouter.tsx
+++ b/waffle_recruit_front/src/pages/AuthorizedRouter.tsx
@@ -1,21 +1,40 @@
 import React, { useEffect } from 'react';
 
-import { Redirect, Route, useHistory } from 'react-router-dom';
+import { Redirect, Route, useHistory, useLocation } from 'react-router-dom';
+import { toast } from 'react-toastify';
+
+import { authRequester, requester } from '../apis/requester';
 
 import ProblemPage from './main';
 import Submit from './submit';
 
 const AuthorizedRouter: React.FC = () => {
   const history = useHistory();
-
+  const location = useLocation();
+  const checkLogin = async () => {
+    try {
+      const res = await authRequester.get('/auth/ping/');
+      if (res.data.login) {
+        return Promise.resolve();
+      } else {
+        return Promise.reject(res);
+      }
+    } catch (e) {
+      toast.error(e);
+    }
+  };
   //check login
   useEffect(() => {
-    const isLoggedIn = true;
-
-    if (!isLoggedIn) {
-      history.push('/signin');
-    }
-  }, [history.location.pathname]);
+    checkLogin().then(
+      () => {
+        toast.success('로그인 되었습니다');
+      },
+      () => {
+        toast.error('로그인이 만료되었습니다.');
+        //    history.push('/signin');
+      }
+    );
+  }, [location.pathname]);
 
   return (
     <>

--- a/waffle_recruit_front/src/pages/main/index.tsx
+++ b/waffle_recruit_front/src/pages/main/index.tsx
@@ -8,6 +8,7 @@ import { useHistory, useLocation, useRouteMatch } from 'react-router-dom';
 import { Button } from 'semantic-ui-react';
 import styled from 'styled-components';
 
+import { authRequester } from '../../apis/requester';
 import Sidebar from '../../component/Sidebar';
 
 import { main, problemStrings, coverletter } from './problems/problemStrings';
@@ -57,7 +58,23 @@ const ProblemPage = () => {
       <ReviewContainer>
         <ReactMarkdown source={`# ${title}`} renderers={{ text: emojiSupport }} />
         <ReactMarkdown source={content} />
-        {prob_num && <Button onClick={() => history.push(`/problem/${prob_num}/submit`)}>제출하기</Button>}
+        {prob_num && (
+          <Button
+            onClick={() =>
+              //history.push(`/problem/${prob_num}/submit`)
+              authRequester.post('/check/0/submit/', { req_data: {} }).then(
+                (res) => {
+                  console.log(res);
+                },
+                (err) => {
+                  console.log(err);
+                }
+              )
+            }
+          >
+            제출하기
+          </Button>
+        )}
         {pathname.includes('coverletter') && (
           <iframe
             src="https://docs.google.com/forms/d/e/1FAIpQLSdUQMy4umFnz0lEOfqZm2D0SBRh_uUam-dLRsIwEmvpoQn_EQ/viewform?embedded=true"

--- a/waffle_recruit_front/src/pages/signin/Signin.tsx
+++ b/waffle_recruit_front/src/pages/signin/Signin.tsx
@@ -7,6 +7,7 @@ import { Button, Form } from 'semantic-ui-react';
 import { requester } from '../../apis/requester';
 import { useAuthContext } from '../../context/authContext';
 import '../containers.css';
+import { saveTokens } from '../../apis/token';
 
 interface User {
   username: string;
@@ -30,8 +31,8 @@ const Signin: React.FC = () => {
 
   const onLoginUser = async (user: User) => {
     try {
-      const res = await requester.post<{ user: string }>('/check/signin/', user);
-      setUser(res.data.user);
+      const res = await requester.post<{ user: string; token: { access: string; refresh: string } }>('/auth/signin/', user);
+      saveTokens(res.data.token);
       history.replace('/main');
     } catch (err) {
       toast.error('가입되지 않은 유저거나 아이디/비밀번호가 틀렸습니다.');

--- a/waffle_recruit_front/src/pages/signup/Signup.tsx
+++ b/waffle_recruit_front/src/pages/signup/Signup.tsx
@@ -41,7 +41,7 @@ const Signup = () => {
   });
 
   const signUpMutation = useMutation(
-    ({ user }: { user: ISignupForm }) => requester.post<{ user: string }>('/check/signup/', user),
+    ({ user }: { user: ISignupForm }) => requester.post<{ user: string }>('/auth/signup/', user),
     {
       onError: () => {
         // TODO 체크 필요


### PR DESCRIPTION
api 연결 문제 없습니다!
- 로그인, 회원가입은 지금 작동하지만, 어차피 밀어버릴 api라 간단하게 테스트만 진행
- 자동 로그인 체크 로직 완성
- refresh token 지금 작업 중

깃헙 소셜로그인 작업하면 일단 apis/token.ts의 함수 이용해서 토큰값 localStorage에 저장시키면 될 것 같습니다